### PR TITLE
Memoization refactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,6 @@ gemspec
 
 gem "rake", "~> 13.0"
 
-gem "rspec", "~> 3.0"
+gem "rspec", "~> 3.2"
 
 gem "rubocop", "~> 1.21"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in fips_lookup.gemspec
 gemspec
 
+gem "csv", "~> 3.2"
+
 gem "rake", "~> 13.0"
 
 gem "rspec", "~> 3.2"

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in fips_code_lookup.gemspec
+# Specify your gem's dependencies in fips_lookup.gemspec
 gemspec
 
 gem "rake", "~> 13.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,13 @@ PATH
   remote: .
   specs:
     fips_lookup (0.1.0)
+      csv (~> 3.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    csv (3.2.8)
     diff-lcs (1.5.0)
     json (2.6.2)
     nokogiri (1.16.2-arm64-darwin)
@@ -56,6 +58,7 @@ PLATFORMS
   arm64-darwin-22
 
 DEPENDENCIES
+  csv (~> 3.2)
   fips_lookup!
   rake (~> 13.0)
   rspec (~> 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fips_code_lookup (0.1.0)
+    fips_lookup (0.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -56,7 +56,7 @@ PLATFORMS
   arm64-darwin-22
 
 DEPENDENCIES
-  fips_code_lookup!
+  fips_lookup!
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     ast (2.4.2)
     diff-lcs (1.5.0)
     json (2.6.2)
-    nokogiri (1.13.6-arm64-darwin)
+    nokogiri (1.15.3-arm64-darwin)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.2.0)
@@ -53,6 +53,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
 
 DEPENDENCIES
   fips_code_lookup!
@@ -62,4 +63,4 @@ DEPENDENCIES
   simple_xlsx_reader
 
 BUNDLED WITH
-   2.3.6
+   2.4.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     ast (2.4.2)
     diff-lcs (1.5.0)
     json (2.6.2)
-    nokogiri (1.15.3-arm64-darwin)
+    nokogiri (1.16.2-arm64-darwin)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.2.0)
@@ -58,9 +58,9 @@ PLATFORMS
 DEPENDENCIES
   fips_lookup!
   rake (~> 13.0)
-  rspec (~> 3.0)
+  rspec (~> 3.2)
   rubocop (~> 1.21)
   simple_xlsx_reader
 
 BUNDLED WITH
-   2.4.17
+   2.5.6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# FipsCodeLookup
+# FipsLookup
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/fips_code_lookup`. To experiment with that code, run `bin/console` for an interactive prompt.
+Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/fips_lookup`. To experiment with that code, run `bin/console` for an interactive prompt.
 
 TODO: Delete this and the text above, and describe your gem
 
@@ -9,7 +9,7 @@ TODO: Delete this and the text above, and describe your gem
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'fips_code_lookup'
+gem 'fips_lookup'
 ```
 
 And then execute:
@@ -18,7 +18,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install fips_code_lookup
+    $ gem install fips_lookup
 
 ## Usage
 
@@ -32,7 +32,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/fips_code_lookup. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/fips_code_lookup/blob/master/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/fips_lookup. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/fips_lookup/blob/master/CODE_OF_CONDUCT.md).
 
 ## License
 
@@ -40,4 +40,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the FipsCodeLookup project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/fips_code_lookup/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the FipsLookup project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/fips_lookup/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome! This gem functions as a lookup that can be used to identify county and state FIPS codes. 
 
-What are FIPS codes? Answer from the United States Federal Communcations Commission (FCC): [source](https://transition.fcc.gov/oet/info/maps/census/fips/fips.txt)
+What are FIPS codes? The United States Federal Communications Commission (FCC) [says:](https://transition.fcc.gov/oet/info/maps/census/fips/fips.txt)
 
 > Federal Information Processing System (FIPS) Codes for States and Counties
 >
@@ -31,15 +31,35 @@ Or install it yourself as:
 
 ## Usage
 
-General usage & expected return: 
+To return the 5 digit FIPS code for the state / county:
+```
+# .county(string, string, boolean)
+# FipsLookup.county(state_param, county_name_param, return_nil=false)
+FipsLookup.county("AL", "Autauga County") => "01001"
+```
+_Note:_
+* `state_param` variable is flexible, preferring the state 2 letter abbreviation or 2 digit FIPS code, but will also find the state by using state name, or the state ANSI code.
 
-Memoization: 
+* `county_name_param` is not flexible and must match spelling (including "County").
 
-Error Handleing:
+* the `.county` method is a representation of the memoized hash class attribute `county_fips`. This means the `.county` method will return previously recorded look-ups before searching the county csv files.
+<hr>
+
+To return the county and state names using a 5 digit FIPS code:
+```
+# .fips_county(string, boolean)
+# .fips_county(fips_param, return_nil=false)
+FipsLookup.fips_county("01001") => ["Autauga County", "AL"]
+```
+_Note:_
+* `fips_param` must be a 5 digit string ex: "01001"
+
+### Error Handling:
+All methods exposed in this gem have an optional boolean parameter `return_nil` that allow you to toggle if an error should be raised or if `nil` should be returned in case of a lookup error.
 
 ## Development
 
-Download the repository locally, and from the directroy run `bin/setup` to install gem dependencies.
+Download the repository locally, and from the directory run `bin/setup` to install gem dependencies.
 
 Check installation and any changes by running `rspec` to run the tests. 
 
@@ -52,7 +72,13 @@ To release a new version, update the version number in `version.rb`, and then ru
 ### New to Ruby?
 On Mac, follow steps 1 and 2 of [this guide](https://www.digitalocean.com/community/tutorials/how-to-install-ruby-on-rails-with-rbenv-on-macos) to install ruby with rbenv using brew.
 
-For PC, consult offical ruby language [installation guides](https://www.ruby-lang.org/en/documentation/installation/).
+For PC, consult official ruby language [installation guides](https://www.ruby-lang.org/en/documentation/installation/).
+
+#### New to this gem?
+
+* The main working file is `lib/fips_lookup.rb` with usage examples in the test file: `spec/fips_lookup_spec.rb`
+* [this pull request](https://github.com/3barroso/fips_lookup/pull/1) contains more details to decisions and considerations when first launching gem.
+
 
 ## Contributing
 
@@ -64,4 +90,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the FipsLookup project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/3barroso/fips_lookup/blob/main/CODE_OF_CONDUCT.md).
+Everyone interacting in the FipsLookup project's codebase, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/3barroso/fips_lookup/blob/main/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # FipsLookup
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/fips_lookup`. To experiment with that code, run `bin/console` for an interactive prompt.
+Welcome! This gem functions as a lookup that can be used to identify county and state FIPS codes. 
 
-TODO: Delete this and the text above, and describe your gem
+What are FIPS codes? Answer from the United States Federal Communcations Commission (FCC): [source](https://transition.fcc.gov/oet/info/maps/census/fips/fips.txt)
+
+> Federal Information Processing System (FIPS) Codes for States and Counties
+>
+> FIPS codes are numbers which uniquely identify geographic areas.  The number of 
+digits in FIPS codes vary depending on the level of geography.  State-level FIPS
+codes have two digits, county-level FIPS codes have five digits of which the 
+first two are the FIPS code of the state to which the county belongs.
+
+FIPS codes are updated by the US census department and [accessed here](https://www.census.gov/library/reference/code-lists/ansi.html)
 
 ## Installation
 
@@ -22,17 +31,32 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+General usage & expected return: 
+
+Memoization: 
+
+Error Handleing:
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+Download the repository locally, and from the directroy run `bin/setup` to install gem dependencies.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+Check installation and any changes by running `rspec` to run the tests. 
+
+Use `bin/console` to open IRB console with FipsLookup gem included and ready to use.
+
+To install this gem onto your local machine, run `bundle exec rake install`. 
+
+To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+### New to Ruby?
+On Mac, follow steps 1 and 2 of [this guide](https://www.digitalocean.com/community/tutorials/how-to-install-ruby-on-rails-with-rbenv-on-macos) to install ruby with rbenv using brew.
+
+For PC, consult offical ruby language [installation guides](https://www.ruby-lang.org/en/documentation/installation/).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/fips_lookup. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/fips_lookup/blob/master/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at the [FipsLookup repo](https://github.com/3barroso/fips_lookup). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/3barroso/fips_lookup/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 
@@ -40,4 +64,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the FipsLookup project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/fips_lookup/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the FipsLookup project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/3barroso/fips_lookup/blob/main/CODE_OF_CONDUCT.md).

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "fips_code_lookup"
+require "fips_lookup"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/fips_lookup.gemspec
+++ b/fips_lookup.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "rubocop", "~>1.21"
-  spec.add_development_dependency "simple_xlsx_reader"
+  # spec.add_development_dependency "simple_xlsx_reader"
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
 end

--- a/fips_lookup.gemspec
+++ b/fips_lookup.gemspec
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require_relative "lib/fips_code_lookup/version"
+require_relative "lib/fips_lookup/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "fips_code_lookup"
-  spec.version = FipsCodeLookup::VERSION
+  spec.name = "fips_lookup"
+  spec.version = FipsLookup::VERSION
   spec.authors = ["Erik Barroso"]
-  spec.email = ["erik.barroso@primary.health"]
+  spec.email = ["erikbarroso22@gmail.com"]
 
   spec.summary = "Stores FIPS codes for US States and Counties"
   # spec.description = "TODO: Write a longer description or delete this line."

--- a/fips_lookup.gemspec
+++ b/fips_lookup.gemspec
@@ -32,9 +32,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "csv", "~> 3.2"
 
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.2"
+  spec.add_development_dependency "rubocop", "~>1.21"
   spec.add_development_dependency "simple_xlsx_reader"
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/fips_code_lookup.rb
+++ b/lib/fips_code_lookup.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "fips_code_lookup/version"
+require 'csv' 
 
 module FipsCodeLookup
   class Error < StandardError; end
@@ -10,34 +11,51 @@ module FipsCodeLookup
                           ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY
                           AS GU MP PR UM VI].freeze
 
-  def self.county(state_param, name)
-    # Headers — AL,01,001,Autauga County,H1
-    File.foreach(county_filename(state_param)) do |row|
-      state_pc, state_fips, county_fips, county, class_code = row.split(",")
-      if county == name
-        return { "county_fips": county_fips, "state_fips": state_fips,
-                 "state_pc": state_pc, "fips_class": class_code.gsub(/\n/, "") }
+  # look up how ruby gem's should throw errors within their functions (404/ county not found / etc.)
+  # ^ when error does it fail gracefully or keep searching & memoizing ?
+
+  def self.county_fips(state_param, county_name_param)
+    # check if file from state exists? 
+    # check if county is within file ?(OR returns nil!!)
+    # ^ check how error handling is stored within instance variable (memoization)
+
+    lookup = [state_param, county_name_param]
+    @_county_fips ||= {}
+    @_county_fips[lookup] ||= county_fips_lookup(state_param, county_name_param)
+  end
+
+  def self.county_fips_lookup(state_param, county_name_param)
+    # return if no file ? (or check if this will exit from errors before)
+
+    CSV.foreach(county_filename(state_param)) do |county_row|
+      #CSV columns: state code, state fips, county fips, county name, county class code
+      if county_row[3].upcase == county_name_param.upcase
+        return county_row[2]
       end
+    end
+    # what to return if county not found?
+  end
+
+  # private ?
+
+  def self.find_state_code(state_param)
+    return state_param.upcase if STATE_POSTAL_CODES.include?(state_param.upcase)
+
+    state_file_name = File.join(File.dirname(__FILE__), "/state.csv")
+    CSV.foreach(state_file_name) do |state_row|
+      # CSV columns: 01,AL,Alabama, 01779775
+      if state_param == state_row[0] || state_param.upcase == state_row[2].upcase || state_param == state_row[3]
+        return state_row[1].upcase
+      end
+
+      # what to return /error & exit if state code is not found?
     end
   end
 
-  def self.state_postal_code(state)
-    state_file = File.join(File.dirname(__FILE__), "/state.csv")
-    # HEADERS — 01,AL,Alabama, 01779775
-    File.foreach(state_file) do |row|
-      state_fips, state_pc, state_name, geo_id = row.split(",")
-      if state == state_fips || state.upcase == state_pc || state.upcase == state_name.upcase || state == geo_id.gsub(/\n/, "")
-        return state_pc
-      end
-    end
-  end
+  def self.county_filename(state_param)
+    state_code = find_state_code(state_param)
 
-  def self.county_filename(state)
-    state_code = if STATE_POSTAL_CODES.include?(state.upcase)
-                   state.upcase
-                 else
-                   state_postal_code(state)
-                 end
+    # error & quit if no state_code ?
     File.join(File.dirname(__FILE__), "/county/#{state_code}.csv")
   end
 end

--- a/lib/fips_lookup.rb
+++ b/lib/fips_lookup.rb
@@ -4,10 +4,17 @@ require_relative "fips_lookup/version"
 require 'csv' 
 
 module FipsLookup
-  STATE_POSTAL_CODES = %w[AL AK AZ AR CA CO CT DE DC FL GA HI ID IL IN IA KS
-                          KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC
-                          ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY
-                          AS GU MP PR UM VI].freeze
+  STATE_CODES = { "AL" => "01", "AK" => "02", "AZ" => "04", "AR" => "05", "CA" => "06", "CO" => "08",
+                  "CT" => "09", "DE" => "10", "DC" => "11", "FL" => "12", "GA" => "13", "HI" => "15",
+                  "ID" => "16", "IL" => "17", "IN" => "18", "IA" => "19", "KS" => "20", "KY" => "21",
+                  "LA" => "22", "ME" => "23", "MD" => "24", "MA" => "25", "MI" => "26", "MN" => "27",
+                  "MS" => "28", "MO" => "29", "MT" => "30", "NE" => "31", "NV" => "32", "NH" => "33",
+                  "NJ" => "34", "NM" => "35", "NY" => "36", "NC" => "37", "ND" => "38", "OH" => "39",
+                  "OK" => "40", "OR" => "41", "PA" => "42", "RI" => "44", "SC" => "45", "SD" => "46",
+                  "TN" => "47", "TX" => "48", "UT" => "49", "VT" => "50", "VA" => "51", "WA" => "53",
+                  "WV" => "54", "WI" => "55", "WY" => "56", "AS" => "60", "GU" => "66", "MP" => "69",
+                  "PR" => "72", "UM" => "74", "VI" => "78"
+                }.freeze
 
   class << self
     attr_accessor :county_fips
@@ -33,12 +40,13 @@ module FipsLookup
     end
 
     def find_state_code(state_param, return_nil = false)
-      return state_param.upcase if STATE_POSTAL_CODES.include?(state_param.upcase)
+      return state_param.upcase if STATE_CODES.key?(state_param.upcase)
+      return STATE_CODES.key(state_param) if STATE_CODES.value?(state_param)
 
       CSV.foreach(state_file) do |state_row|
         # state code (01), state postal code (AL), state name (Alabama), state ansi code (01779775)
-        if state_param == state_row[0] || state_param.upcase == state_row[2].upcase || state_param == state_row[3]
-          return state_row[1].upcase if STATE_POSTAL_CODES.include?(state_row[1].upcase)
+        if state_param.upcase == state_row[2].upcase || state_param == state_row[3]
+          return state_row[1]
         end
       end
 

--- a/lib/fips_lookup.rb
+++ b/lib/fips_lookup.rb
@@ -21,7 +21,7 @@ module FipsLookup
     attr_accessor :county_fips
 
     def county(state_param, county_name_param, return_nil = false)
-      lookup = [state_param.upcase, county_name_param.upcase]  # upcase?
+      lookup = [state_param.upcase, county_name_param.upcase]
       @county_fips ||= {}
       @county_fips[lookup] ||= county_lookup(state_param, county_name_param, return_nil)
     end

--- a/lib/fips_lookup.rb
+++ b/lib/fips_lookup.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "fips_lookup/version"
-require 'csv' 
+require 'csv'
+require 'pathname'
 
 module FipsLookup
   STATE_CODES = { "AL" => "01", "AK" => "02", "AZ" => "04", "AR" => "05", "CA" => "06", "CO" => "08",
@@ -56,11 +57,11 @@ module FipsLookup
     private
 
     def state_county_file(state_code)
-      File.join(File.dirname(__FILE__), "/county/#{state_code}.csv")
+      Pathname.getwd + "lib/county/#{state_code}.csv"
     end
 
     def state_file
-      File.join(File.dirname(__FILE__), "/state.csv")
+      Pathname.getwd + "lib/state.csv"
     end
   end
 end

--- a/lib/fips_lookup.rb
+++ b/lib/fips_lookup.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require_relative "fips_code_lookup/version"
+require_relative "fips_lookup/version"
 require 'csv' 
 
-module FipsCodeLookup
+module FipsLookup
   class Error < StandardError; end
 
   STATE_POSTAL_CODES = %w[AL AK AZ AR CA CO CT DE DC FL GA HI ID IL IN IA KS
@@ -14,17 +14,17 @@ module FipsCodeLookup
   # look up how ruby gem's should throw errors within their functions (404/ county not found / etc.)
   # ^ when error does it fail gracefully or keep searching & memoizing ?
 
-  def self.county_fips(state_param, county_name_param)
+  def self.county(state_param, county_name_param)
     # check if file from state exists? 
     # check if county is within file ?(OR returns nil!!)
     # ^ check how error handling is stored within instance variable (memoization)
 
     lookup = [state_param, county_name_param]
     @_county_fips ||= {}
-    @_county_fips[lookup] ||= county_fips_lookup(state_param, county_name_param)
+    @_county_fips[lookup] ||= county_lookup(state_param, county_name_param)
   end
 
-  def self.county_fips_lookup(state_param, county_name_param)
+  def self.county_lookup(state_param, county_name_param)
     # return if no file ? (or check if this will exit from errors before)
 
     CSV.foreach(county_filename(state_param)) do |county_row|
@@ -35,6 +35,8 @@ module FipsCodeLookup
     end
     # what to return if county not found?
   end
+
+  # state code lookups (geo id - memoize whole state file ?)
 
   # private ?
 

--- a/lib/fips_lookup.rb
+++ b/lib/fips_lookup.rb
@@ -31,7 +31,7 @@ module FipsLookup
       return nil if state_code.nil?
 
       CSV.foreach(state_county_file(state_code)) do |county_row|
-        # state (AL), state code (01), county fips (001), county name (Augtauga County), county class code (H1)
+        # county_row = state (AL), state code (01), county fips (001), county name (Augtauga County), county class code (H1)
         if county_row[3].upcase == county_name_param.upcase
           return county_row[1] + county_row[2]
         end
@@ -45,7 +45,7 @@ module FipsLookup
       return STATE_CODES.key(state_param) if STATE_CODES.value?(state_param)
 
       CSV.foreach(state_file) do |state_row|
-        # state code (01), state postal code (AL), state name (Alabama), state ansi code (01779775)
+        # state_row = state code (01), state postal code (AL), state name (Alabama), state ansi code (01779775)
         if state_param.upcase == state_row[2].upcase || state_param == state_row[3]
           return state_row[1]
         end

--- a/lib/fips_lookup.rb
+++ b/lib/fips_lookup.rb
@@ -21,7 +21,7 @@ module FipsLookup
     attr_accessor :county_fips
 
     def county(state_param, county_name_param, return_nil = false)
-      lookup = [state_param, county_name_param]
+      lookup = [state_param.upcase, county_name_param.upcase]  # upcase?
       @county_fips ||= {}
       @county_fips[lookup] ||= county_lookup(state_param, county_name_param, return_nil)
     end

--- a/lib/fips_lookup.rb
+++ b/lib/fips_lookup.rb
@@ -25,7 +25,7 @@ module FipsLookup
       CSV.foreach(state_county_file(state_code)) do |county_row|
         # state (AL), state code (01), county fips (001), county name (Augtauga County), county class code (H1)
         if county_row[3].upcase == county_name_param.upcase
-          return county_row[2]
+          return county_row[1] + county_row[2]
         end
       end
 

--- a/lib/fips_lookup.rb
+++ b/lib/fips_lookup.rb
@@ -4,52 +4,55 @@ require_relative "fips_lookup/version"
 require 'csv' 
 
 module FipsLookup
-
   STATE_POSTAL_CODES = %w[AL AK AZ AR CA CO CT DE DC FL GA HI ID IL IN IA KS
                           KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC
                           ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY
                           AS GU MP PR UM VI].freeze
 
-  def self.county(state_param, county_name_param, return_nil = false)
-    lookup = [state_param, county_name_param]
-    @_county_fips ||= {}
-    @_county_fips[lookup] ||= county_lookup(state_param, county_name_param, return_nil)
-  end
+  class << self
+    attr_accessor :county_fips
 
-  def self.county_lookup(state_param, county_name_param, return_nil = false)
-    state_code = find_state_code(state_param, return_nil)
-    return nil if state_code.nil?
-
-    CSV.foreach(state_county_file(state_code)) do |county_row|
-      # state (AL), state code (01), county fips (001), county name (Augtauga County), county class code (H1)
-      if county_row[3].upcase == county_name_param.upcase
-        return county_row[2]
-      end
+    def county(state_param, county_name_param, return_nil = false)
+      lookup = [state_param, county_name_param]
+      @county_fips ||= {}
+      @county_fips[lookup] ||= county_lookup(state_param, county_name_param, return_nil)
     end
 
-    raise StandardError, "No county found matching: #{county_name_param}" unless return_nil
-  end
+    def county_lookup(state_param, county_name_param, return_nil = false)
+      state_code = find_state_code(state_param, return_nil)
+      return nil if state_code.nil?
 
-  def self.find_state_code(state_param, return_nil = false)
-    return state_param.upcase if STATE_POSTAL_CODES.include?(state_param.upcase)
-
-    CSV.foreach(state_file) do |state_row|
-      # state code (01), state postal code (AL), state name (Alabama), state ansi code (01779775)
-      if state_param == state_row[0] || state_param.upcase == state_row[2].upcase || state_param == state_row[3]
-        return state_row[1].upcase if STATE_POSTAL_CODES.include?(state_row[1].upcase)
+      CSV.foreach(state_county_file(state_code)) do |county_row|
+        # state (AL), state code (01), county fips (001), county name (Augtauga County), county class code (H1)
+        if county_row[3].upcase == county_name_param.upcase
+          return county_row[2]
+        end
       end
+
+      raise StandardError, "No county found matching: #{county_name_param}" unless return_nil
     end
 
-    raise StandardError, "No state found matching: #{state_param}" unless return_nil
-  end
+    def find_state_code(state_param, return_nil = false)
+      return state_param.upcase if STATE_POSTAL_CODES.include?(state_param.upcase)
 
-  private
+      CSV.foreach(state_file) do |state_row|
+        # state code (01), state postal code (AL), state name (Alabama), state ansi code (01779775)
+        if state_param == state_row[0] || state_param.upcase == state_row[2].upcase || state_param == state_row[3]
+          return state_row[1].upcase if STATE_POSTAL_CODES.include?(state_row[1].upcase)
+        end
+      end
 
-  def self.state_county_file(state_code)
-    File.join(File.dirname(__FILE__), "/county/#{state_code}.csv")
-  end
+      raise StandardError, "No state found matching: #{state_param}" unless return_nil
+    end
 
-  def self.state_file
-    File.join(File.dirname(__FILE__), "/state.csv")
+    private
+
+    def state_county_file(state_code)
+      File.join(File.dirname(__FILE__), "/county/#{state_code}.csv")
+    end
+
+    def state_file
+      File.join(File.dirname(__FILE__), "/state.csv")
+    end
   end
 end

--- a/lib/fips_lookup.rb
+++ b/lib/fips_lookup.rb
@@ -54,6 +54,25 @@ module FipsLookup
       raise StandardError, "No state found matching: #{state_param}" unless return_nil
     end
 
+    def fips_county(fips_param, return_nil = false)
+      unless fips_param.is_a?(String) && fips_param.length == 5
+        return_nil ? (return nil) : (raise StandardError, "FIPS input must be 5 digit string")
+      end
+      state_code = STATE_CODES.key(fips_param[0..1])
+
+      if state_code.nil?
+        return_nil ? (return nil) : (raise StandardError, "Could not find state with FIPS: #{fips_param[0..1]}")
+      end
+
+      CSV.foreach(state_county_file(state_code)) do |county_row|
+        if county_row[2] == fips_param[2..4]
+          return [county_row[3], state_code]
+        end
+      end
+
+      raise StandardError, "Could not find #{state_code} county matching FIPS: #{fips_param[2..4]}" unless return_nil
+    end
+
     private
 
     def state_county_file(state_code)

--- a/lib/fips_lookup/version.rb
+++ b/lib/fips_lookup/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module FipsCodeLookup
+module FipsLookup
   VERSION = "0.1.0"
 end

--- a/sig/fips_lookup.rbs
+++ b/sig/fips_lookup.rbs
@@ -1,4 +1,4 @@
-module FipsCodeLookup
+module FipsLookup
   VERSION: String
   # See the writing guide of rbs: https://github.com/ruby/rbs#guides
 end

--- a/spec/fips_lookup_spec.rb
+++ b/spec/fips_lookup_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe FipsLookup do
     end
 
     context "with an invalid county param" do
-      context "and return_nil paramater is not used" do
+      context "and return_nil parameter is not used" do
         it "returns an error" do
           expect{FipsLookup.county_lookup("AL", "Autauga")}.to raise_error(StandardError, "No county found matching: Autauga")
         end
       end
-      context "and return_nil paramater is used" do
+      context "and return_nil parameter is used" do
         it "returns nil" do
           expect(FipsLookup.county_lookup("Alabama", "Autauga", true)).to eq(nil)
         end
@@ -27,12 +27,12 @@ RSpec.describe FipsLookup do
     end
 
     context "with an invalid state param" do
-      context "and return_nil paramater is not used" do
+      context "and return_nil parameter is not used" do
         it "returns an error" do
           expect{FipsLookup.county_lookup("ZZ", "County")}.to raise_error(StandardError, "No state found matching: ZZ")
         end
       end
-      context "and return_nil paramater is used" do
+      context "and return_nil parameter is used" do
         it "returns nil" do
           expect(FipsLookup.county_lookup("ZZ", "County", true)).to eq(nil)
         end
@@ -41,7 +41,7 @@ RSpec.describe FipsLookup do
   end
 
   describe ".county" do
-    it "populates a memoized hash attribute accessor with state paramater and county paramater as lookups" do
+    it "populates a memoized hash attribute accessor with state parameter and county parameter as lookups" do
       expect(FipsLookup.county("AL", "Autauga County")).to eq("01001")
 
       lookup = ["AL", "Autauga County"]
@@ -53,6 +53,45 @@ RSpec.describe FipsLookup do
     it "is a hash with the same number of key value pairs as rows in the state.csv file" do
       state_file_path = Pathname.getwd + "lib/state.csv"
       expect(FipsLookup::STATE_CODES.length - 1).to eq(`wc -l #{state_file_path}`.to_i)
+    end
+  end
+
+  describe ".fips_county" do
+    it "takes in a 5 digit code and finds the corresponding state county name" do
+      expect(FipsLookup.fips_county("01001")).to eq(["Autauga County", "AL"])
+    end
+
+    context "when the input is not valid" do
+      it "returns an error" do
+        expect{FipsLookup.fips_county(12345)}.to raise_error(StandardError, "FIPS input must be 5 digit string")
+        expect{FipsLookup.fips_county("123")}.to raise_error(StandardError, "FIPS input must be 5 digit string")
+      end
+
+      it "returns nil if optional parameter is true" do
+        expect(FipsLookup.fips_county(12345, true)).to be nil
+        expect(FipsLookup.fips_county("123", true)).to be nil
+      end
+    end
+
+    context "when the input is valid but state code cannot be found" do
+      it "returns an error" do
+        expect{FipsLookup.fips_county("03123")}.to raise_error(StandardError, "Could not find state with FIPS: 03")
+      end
+
+      it "returns nil if optional parameter is true" do
+        expect(FipsLookup.fips_county("03123", true)).to be nil
+      end
+    end
+
+    context "when the input is valid but county can not be found" do
+      it "returns an error" do
+        expect{FipsLookup.fips_county("01999")}.to raise_error(StandardError, "Could not find AL county matching FIPS: 999")
+
+      end
+
+      it "returns nil if optional parameter is true" do
+        expect(FipsLookup.fips_county("01999", true)).to be nil
+      end
     end
   end
 end

--- a/spec/fips_lookup_spec.rb
+++ b/spec/fips_lookup_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe FipsCodeLookup do
+RSpec.describe FipsLookup do
   it "has a version number" do
-    expect(FipsCodeLookup::VERSION).not_to be nil
+    expect(FipsLookup::VERSION).not_to be nil
   end
 
   it "does something useful" do

--- a/spec/fips_lookup_spec.rb
+++ b/spec/fips_lookup_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe FipsLookup do
     it "populates a memoized hash attribute accessor with state parameter and county parameter as lookups" do
       expect(FipsLookup.county("AL", "Autauga County")).to eq("01001")
 
-      lookup = ["AL", "Autauga County"]
+      lookup = ["AL".upcase, "Autauga County".upcase]
       expect(FipsLookup.county_fips[lookup]).to eq("01001")
     end
   end

--- a/spec/fips_lookup_spec.rb
+++ b/spec/fips_lookup_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'pathname'
 
 RSpec.describe FipsLookup do
   it "has a version number" do
@@ -45,6 +46,13 @@ RSpec.describe FipsLookup do
 
       lookup = ["AL", "Autauga County"]
       expect(FipsLookup.county_fips[lookup]).to eq("01001")
+    end
+  end
+
+  describe "STATE_CODES" do
+    it "is a hash with the same number of key value pairs as rows in the state.csv file" do
+      state_file_path = Pathname.getwd + "lib/state.csv"
+      expect(FipsLookup::STATE_CODES.length - 1).to eq(`wc -l #{state_file_path}`.to_i)
     end
   end
 end

--- a/spec/fips_lookup_spec.rb
+++ b/spec/fips_lookup_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe FipsLookup do
   describe ".county_lookup" do
     context "with searchable state and county params" do
       it "returns the proper fips code" do
-        expect(FipsLookup.county_lookup("Al", "Autauga County")).to eq("001")
+        expect(FipsLookup.county_lookup("Al", "Autauga County")).to eq("01001")
       end
     end
 
@@ -41,10 +41,10 @@ RSpec.describe FipsLookup do
 
   describe ".county" do
     it "populates a memoized hash attribute accessor with state paramater and county paramater as lookups" do
-      expect(FipsLookup.county("AL", "Autauga County")).to eq("001")
+      expect(FipsLookup.county("AL", "Autauga County")).to eq("01001")
 
       lookup = ["AL", "Autauga County"]
-      expect(FipsLookup.county_fips[lookup]).to eq("001")
+      expect(FipsLookup.county_fips[lookup]).to eq("01001")
     end
   end
 end

--- a/spec/fips_lookup_spec.rb
+++ b/spec/fips_lookup_spec.rb
@@ -5,7 +5,46 @@ RSpec.describe FipsLookup do
     expect(FipsLookup::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  describe ".county_lookup" do
+    context "with searchable state and county params" do
+      it "returns the proper fips code" do
+        expect(FipsLookup.county_lookup("Al", "Autauga County")).to eq("001")
+      end
+    end
+
+    context "with an invalid county param" do
+      context "and return_nil paramater is not used" do
+        it "returns an error" do
+          expect{FipsLookup.county_lookup("AL", "Autauga")}.to raise_error(StandardError, "No county found matching: Autauga")
+        end
+      end
+      context "and return_nil paramater is used" do
+        it "returns nil" do
+          expect(FipsLookup.county_lookup("Alabama", "Autauga", true)).to eq(nil)
+        end
+      end
+    end
+
+    context "with an invalid state param" do
+      context "and return_nil paramater is not used" do
+        it "returns an error" do
+          expect{FipsLookup.county_lookup("ZZ", "County")}.to raise_error(StandardError, "No state found matching: ZZ")
+        end
+      end
+      context "and return_nil paramater is used" do
+        it "returns nil" do
+          expect(FipsLookup.county_lookup("ZZ", "County", true)).to eq(nil)
+        end
+      end
+    end
+  end
+
+  describe ".county" do
+    it "populates a memoized hash attribute accessor with state paramater and county paramater as lookups" do
+      expect(FipsLookup.county("AL", "Autauga County")).to eq("001")
+
+      lookup = ["AL", "Autauga County"]
+      expect(FipsLookup.county_fips[lookup]).to eq("001")
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "fips_code_lookup"
+require "fips_lookup"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
### Main objective
Add memoization hash that stores previously searched values during the instance of the class execution.  Goal is to reduce calls to files and reading / comparing each line. 

### Secondary objective
Update naming after repository fork. Finalize basics for initial gem release - documentation, spec tests, error handling, and gem dependencies.

### Notes / Considerations
* Adds optional parameter to use as error handling that allows 'nil' returns instead of raising an error (`return_nil`) if the searching parameters do not find a state / county
* uses `csv` lib to parse state and county files instead of `FILE` — no assignment of variables needed for comparison, no splitting or gsub row manipulation. 
* * Adds `csv` to gemfile and gemspec as runtime dependency because ruby 3.4 will remove csv from its standard library per ruby 3.3 [release notes](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/#:~:text=Standard%20library%20updates) 
* memoized hash is added as attribute accessor to the class
* state abbreviation and county name search parameters are used as the hash value lookup
* makes STATE_CODES constant hash of state code --> abbreviation key/value lookups
* adds `.fips_county` method as reverse lookup to go from 5 digit fips code to state and county name
* general spec coverage for the main county lookup working method and its memorization hash
* name changes after forking repo for class `FipsLookup.county("MI", "Wayne County")`
* updates gemspec to specify gems that are development vs. runtime dependencies

### Future adds?
* specs or benchmarks for comparisons between `county_lookup` and `county` memoization method calls 
* state hash attribute for memoization so 'state.csv' file doesn't have to be accessed as frequently

### Resources that helped / inspired
* an original [FIPS county gem](https://github.com/raypereda/fips-county-codes) — has downloads but is out of date and potentially gives incorrect responses if duplicate county name is given without state name.
* Overview [guide to memoization](https://blog.appsignal.com/2022/12/20/a-guide-to-memoization-in-ruby.html)
* [Examples of memoization guide](https://www.justinweiss.com/articles/4-simple-memoization-patterns-in-ruby-and-one-gem/) — memoization with parameters
* [Advanced memoization](https://michaeljherold.com/articles/memoization-in-ruby/)
* [Error handling reference guides](https://www.sitepoint.com/ruby-error-handling-beyond-basics/)