### PR TITLE
Public csv files and file path methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   TargetRubyVersion: 2.6
+  NewCops: enable
 
 Style/StringLiterals:
   Enabled: true

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Or install it yourself as:
     $ gem install fips_lookup
 
 ## Usage
+<br>
 
 ### County info from lookup:  [.county(state_param: "state", county_name: "county name", _return_nil: false_)](/fips_lookup/lib/fips_lookup.rb?#L24)
 
@@ -66,7 +67,7 @@ The `county_fips` hash is built of key value pairs that grows as the `.county` m
 ```
 FipsLookup.county_fips # => { ["AL", "Autauga County"] => {:state_code=>"AL", :fips=>"01001", :name=>"Autauga County", :class_code=>"H1"} }
 ```
-
+<br>
 <hr>
 
 ### State / County lookup using FIPS code [.fips_county(fips: "fips", return_nil: _return_nil=false_)](/fips_lookup/lib/fips_lookup.rb?#L38)
@@ -81,7 +82,6 @@ FipsLookup.fips_county(fips: "01001") # => ["Autauga County", "AL"]
     * Ex: `FipsLookup.fips_county(fips: "03000", return_nil: true) # => nil`
 
 <br>
-
 <hr>
 
 ### State info from lookup [.state(state_param: "state", _return_nil: false_)](/fips_lookup/lib/fips_lookup.rb?#L33)
@@ -103,7 +103,44 @@ Can also be used for quick lookup translation between state 2-character abbrevia
 FipsLookup::STATE_CODES["AL"] #=> "01"
 FipsLookup::STATE_CODES.key("01") # => "AL"
 ```
+<br>
+<hr>
 
+### Accessing county and state `.csv` files in your Rails app
+
+Data `csv` files are made accessible incase extra configuration is needed. Here is an example in a Rails application that displays the list of state and county names within a form: 
+
+Display state codes in select option dropdown:
+```
+# in controller.rb
+@state_options = []
+CSV.foreach(FipsLookup.state_file) do |state_row|
+    @state_options << [state_row[2], state_row[1]]
+end
+```
+
+```
+# in html.erb (within `form_with do |form|` block)
+<%= form.label :state, style: "display: block" %>
+<%= form.select :state, @state_options %>
+```
+
+
+With state code as param input, create county dropdown option
+```
+# in controller.rb
+state_code = address_params[:state]
+@county_options = []
+CSV.foreach(FipsLookup.county_file(state_code:)) do |county_row|
+    @county_options << county_row[3]
+end
+```
+
+```
+# in html.erb (within `form_with do |form|` block)
+<%= form.label :county, style: "display: block" %>
+<%= form.select :county, @county_options %>
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ FipsLookup::STATE_CODES.key("01") # => "AL"
 
 ### Accessing county and state `.csv` files in your Rails app
 
-Data `csv` files are made accessible incase extra configuration is needed. Here is an example in a Rails application that displays the list of state and county names within a form: 
+Data `csv` files are made accessible incase extra configuration is needed. Here is an example in a Rails application that displays the list of state and county names within a form. This is done by accessing the CSV files included in this gem, examples below are from Rails 7 app called [Build With](https://github.com/3barroso/build_with)
 
-Display state codes in select option dropdown:
+Display state codes in a select option dropdown by using CSV on the FipsLookup method accessing the state.csv file ( `FipsLookup.state_file #=> "path/to/data/state.csv"` )
 ```
 # in controller.rb
 @state_options = []
@@ -126,7 +126,7 @@ end
 ```
 
 
-With state code as param input, create county dropdown option
+Display County name options in a select option dropdown by using CSV on the FipsLookup method accessing the county specific .csv file ( `FipsLookup.county_file(state_code: "MI") #=> "path/to/data/county/MI.csv"` )
 ```
 # in controller.rb
 state_code = address_params[:state]

--- a/README.md
+++ b/README.md
@@ -106,11 +106,26 @@ FipsLookup::STATE_CODES.key("01") # => "AL"
 <br>
 <hr>
 
-### Accessing county and state `.csv` files in your Rails app
+### Finding state abbreviation with flexible input [.find_state_code(state_param: "state", _return_nil: false_)](/fips_lookup/lib/fips_lookup.rb?#L52)
+
+* `state_param` - (String) flexible - able to find the state using its' 2 letter abbreviation ("AL"), 2 digit FIPS number ("01"), state name ("Alabama"), or the state ANSI code ("01779775").
+* `return_nil` - (Boolean) is an optional parameter that when used overrides any Errors from input and returns nil.
+
+```
+FipsLookup.find_state_code(state_param: "MicHiGan") # => "MI"
+```
+
+<br>
+<hr>
+
+## Accessing county and state `.csv` files in your Rails app
 
 Data `csv` files are made accessible incase extra configuration is needed. Here is an example in a Rails application that displays the list of state and county names within a form. This is done by accessing the CSV files included in this gem, examples below are from Rails 7 app called [Build With](https://github.com/3barroso/build_with)
 
+### Path to state.csv file [.state_file](/fips_lookup/lib/fips_lookup.rb?#L64)
+
 Display state codes in a select option dropdown by using CSV on the FipsLookup method accessing the state.csv file ( `FipsLookup.state_file #=> "path/to/data/state.csv"` )
+
 ```
 # in controller.rb
 @state_options = []
@@ -125,11 +140,15 @@ end
 <%= form.select :state, @state_options %>
 ```
 
+### Path to state specific county csv files [.county_file(state_code: "state param")](/fips_lookup/lib/fips_lookup.rb?#L59)
 
 Display County name options in a select option dropdown by using CSV on the FipsLookup method accessing the county specific .csv file ( `FipsLookup.county_file(state_code: "MI") #=> "path/to/data/county/MI.csv"` )
+
+* `state_param` – strict parameter, must be string abbreviation of State code (suggested usage is to call `.find_state_code` above first)
+
 ```
 # in controller.rb
-state_code = address_params[:state]
+state_code = address_params[:state] # or use find_state_code from user input
 @county_options = []
 CSV.foreach(FipsLookup.county_file(state_code:)) do |county_row|
     @county_options << county_row[3]

--- a/fips_lookup.gemspec
+++ b/fips_lookup.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary = "Stores FIPS codes for US States and Counties"
   # spec.description = "TODO: Write a longer description or delete this line."
-  # spec.homepage = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage = "https://github.com/3barroso/fips_lookup"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 2.6.0"
 
@@ -30,6 +30,9 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.files += Dir["lib/data/county/*.csv"]
+  spec.files += Dir["lib/data/*.csv"]
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "csv", "~> 3.2"

--- a/lib/fips_lookup.rb
+++ b/lib/fips_lookup.rb
@@ -2,7 +2,6 @@
 
 require_relative "fips_lookup/version"
 require "csv"
-require "pathname"
 
 # worker for county, state, fips lookups
 module FipsLookup

--- a/lib/fips_lookup.rb
+++ b/lib/fips_lookup.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 require_relative "fips_lookup/version"
-require 'csv'
-require 'pathname'
+require "csv"
+require "pathname"
 
+# worker for county, state, fips lookups
 module FipsLookup
   STATE_CODES = { "AL" => "01", "AK" => "02", "AZ" => "04", "AR" => "05", "CA" => "06", "CO" => "08",
                   "CT" => "09", "DE" => "10", "DC" => "11", "FL" => "12", "GA" => "13", "HI" => "15",
@@ -18,8 +19,7 @@ module FipsLookup
                 }.freeze
 
   class << self
-    attr_accessor :county_fips
-    attr_accessor :state_fips
+    attr_accessor :county_fips, :state_fips
 
     def county(state_param:, county_name:, return_nil: false)
       state_code = find_state_code(state_param, return_nil)
@@ -43,30 +43,28 @@ module FipsLookup
       state_code = find_state_code(fips[0..1], return_nil)
       return nil if state_code.nil?
 
-      CSV.foreach(state_county_file(state_code)) do |county_row|
-        if county_row[2] == fips[2..4]
-          return [county_row[3], state_code]
-        end
+      CSV.foreach(county_file(state_code: state_code)) do |county_row|
+        return [county_row[3], state_code] if county_row[2] == fips[2..4]
       end
 
       raise StandardError, "Could not find county with fips: #{fips[2..4]}, in: #{state_code}" unless return_nil
     end
 
-    private
-
-    def state_county_file(state_code)
-      Pathname.getwd + "lib/data/county/#{state_code}.csv"
+    def county_file(state_code:)
+      "#{File.expand_path(__dir__)}/data/county/#{state_code}.csv"
     end
 
     def state_file
-      Pathname.getwd + "lib/data/state.csv"
+      "#{File.expand_path(__dir__)}/data/state.csv"
     end
 
+    private
+
     def county_lookup(state_code, county_name_param, return_nil)
-      CSV.foreach(state_county_file(state_code)) do |county_row|
+      CSV.foreach(county_file(state_code: state_code)) do |county_row|
         # county_row => state_code (AL), state fips (01), county fips (001), name (Augtauga County), class code (H1)
         if county_row[3].upcase == county_name_param.upcase
-          return {state_code: county_row[0], fips: (county_row[1] + county_row[2]), name: county_row[3], class_code: county_row[4]}
+          return {state_code: county_row[0], fips: (county_row[1] + county_row[2]), name: county_row[3], class_code: county_row[4] }
         end
       end
       return_nil ? (return {}) : (raise StandardError, "No county found matching: #{county_name_param}" unless return_nil)
@@ -75,14 +73,15 @@ module FipsLookup
     def find_state_code(state_param, return_nil)
       return state_param.upcase if STATE_CODES.key?(state_param.upcase)
       return STATE_CODES.key(state_param) if STATE_CODES.value?(state_param)
-      return state(state_param: state_param, return_nil: return_nil)[:code]
+
+      state(state_param: state_param, return_nil: return_nil)[:code]
     end
 
     def state_lookup(state_param, return_nil = false)
       CSV.foreach(state_file) do |state_row|
         # state_row => state fips (01), state code (AL), state name (Alabama), ansi (01779775)
-        if ( state_row[0] == state_param || state_row[1] == state_param.upcase ||
-            state_row[2].upcase == state_param.upcase || state_row[3] == state_param )
+        if state_row[0] == state_param || state_row[1] == state_param.upcase ||
+           state_row[2].upcase == state_param.upcase || state_row[3] == state_param
           return { fips: state_row[0], code: state_row[1], name: state_row[2], ansi: state_row[3] }
         end
       end


### PR DESCRIPTION
**Main objective:**
* Add data/*.csv files to included gem files and allow access for use

**Purpose:**
* ability to add flexibility for Rails app access/implementations

**Examples:**
* [Build With](https://github.com/3barroso/build_with) — address forms use state and county dropdowns 

**Considerations:**
* `pathname` gem is no longer used for `FILE` class usage in accessing gem files from Rails app (is there another pathname method to create same functionality achieved as FILE here?)